### PR TITLE
Bugfix: no LUKS devices causes a (harmless) error message

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-luksencryption (2.1.1) unstable; urgency=medium
+
+  * Bugfix: no LUKS devices present would cause an error message.
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Wed, 13 Jan 2016 10:59:49 +0000
+
 openmediavault-luksencryption (2.1.0) unstable; urgency=high
 
   * Tested on OMV 3.0.

--- a/usr/share/php/openmediavault/luks.inc
+++ b/usr/share/php/openmediavault/luks.inc
@@ -41,7 +41,7 @@ class OMVLuksContainers extends OMVObject {
     public static function enumerate() {
         $cmd = "export LANG=C; blkid -t TYPE=crypto_LUKS -o device 2>/dev/null";
         @OMVUtil::exec($cmd, $output, $result);
-        if($result !== 0)
+        if(!in_array($result, array(0,2), TRUE))
             return FALSE;
         $list = array();
         // Parse command output:


### PR DESCRIPTION
More info: blkid -t returns code 2 when no devices found.