### PR TITLE
Add column for the LUKS uuid in the container grid

### DIFF
--- a/var/www/openmediavault/js/omv/module/admin/storage/luks/Containers.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/luks/Containers.js
@@ -1320,6 +1320,16 @@ Ext.define("OMV.module.admin.storage.luks.Containers", {
             }
         },{
             xtype: "textcolumn",
+            text: _("LUKS UUID"),
+            hidden: true,
+            sortable: true,
+            dataIndex: "uuid",
+            stateId: "uuid",
+            renderer: function(value) {
+                return "UUID=" + Ext.String.htmlEncode(value);
+            }
+        },{
+            xtype: "textcolumn",
             text: _("Key slots in use"),
             sortable: true,
             dataIndex: "usedslots",


### PR DESCRIPTION
This is for displaying the uuid luks signature, the column is hidden by default