### PR TITLE
Fix the display of used slot numbers. Add luks version column(hidden)

### DIFF
--- a/usr/share/openmediavault/engined/rpc/luks.inc
+++ b/usr/share/openmediavault/engined/rpc/luks.inc
@@ -82,7 +82,8 @@ class OMVRpcServiceLuksMgmt extends \OMV\Rpc\ServiceAbstract {
                 "size"                  => $luks->getSize(),
                 "unlocked"              => $luks->isOpen(),
                 "decrypteddevicefile"   => $luks->getDecryptedDeviceFile(),
-                "usedslots"             => $luks->getUsedKeySlots()
+                "usedslots"             => $luks->getUsedKeySlots(),
+                "luksversion"           => $luks->getLuksVersion()
             ];
         }
         return $result;

--- a/usr/share/php/openmediavault/system/storage/luks/container.inc
+++ b/usr/share/php/openmediavault/system/storage/luks/container.inc
@@ -121,6 +121,7 @@ class Container extends \OMV\System\Storage\StorageDevice {
         $this->freeKeySlots           = 8;
         $this->deviceMapperDeviceFile = "";
         $this->deviceMapperName       = "";
+        $this->getLuksVersion         = "";
 
         // Look up the UUID for the LUKS container
         $cmd = sprintf("cryptsetup luksUUID %s", $this->getDeviceFile());
@@ -160,8 +161,18 @@ class Container extends \OMV\System\Storage\StorageDevice {
         $process = new Process($cmd);
         $process->execute($output, $exitStatus);
         $this->headerInfo = $output;
-        $this->usedKeySlots = count(preg_grep("/^Key Slot \d: ENABLED$/",
+
+        $version = explode(':',preg_replace('/\s/','',implode('', preg_grep("/^Version:/", $this->headerInfo))))[1];
+        
+        $this->luksVersion = $version;
+        if ($version == "1") {
+            $this->usedKeySlots = count(preg_grep("/^Key Slot \d: ENABLED$/",
+                                                 $this->headerInfo));
+        } elseif ($version == "2" ) {
+            $this->usedKeySlots = count(preg_grep("/^\s+(\d:\s)(luks2)/",
                                                 $this->headerInfo));
+        }
+
         $this->freeKeySlots = count(preg_grep("/^Key Slot \d: DISABLED$/",
                                                 $this->headerInfo));
 
@@ -257,6 +268,17 @@ class Container extends \OMV\System\Storage\StorageDevice {
         if ($this->getData() === FALSE)
             return FALSE;
         return $this->usedKeySlots;
+    }
+
+
+    /**
+     * Version of luks.
+     * @return version number of luks.
+     */
+    public function getLuksVersion() {
+        if ($this->getData() === FALSE)
+            return FALSE;
+        return $this->luksVersion;
     }
 
     /**

--- a/var/www/openmediavault/js/omv/module/admin/storage/luks/Containers.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/luks/Containers.js
@@ -1346,9 +1346,9 @@ Ext.define("OMV.module.admin.storage.luks.Containers", {
             stateId: "usedslots",
             renderer: function(value,metaData,record) {
                 version = record.get('luksversion');
-                if (record.get("luksversion") == "1") {
+                if (version == "1") {
                     suffix = "/8";
-                } else {
+                } else if (version == "2") {
                     suffix = "/32";
                 }
                 return Ext.String.htmlEncode(value) + suffix;

--- a/var/www/openmediavault/js/omv/module/admin/storage/luks/Containers.js
+++ b/var/www/openmediavault/js/omv/module/admin/storage/luks/Containers.js
@@ -1330,12 +1330,28 @@ Ext.define("OMV.module.admin.storage.luks.Containers", {
             }
         },{
             xtype: "textcolumn",
+            text: _("Version"),
+            hidden: true,
+            sortable: true,
+            dataIndex: "luksversion",
+            stateId: "luksversion",
+            renderer: function(value) {
+                return "LUKS" + Ext.String.htmlEncode(value);
+            }
+        },{
+            xtype: "textcolumn",
             text: _("Key slots in use"),
             sortable: true,
             dataIndex: "usedslots",
             stateId: "usedslots",
-            renderer: function(value) {
-                return Ext.String.htmlEncode(value) + "/8";
+            renderer: function(value,metaData,record) {
+                version = record.get('luksversion');
+                if (record.get("luksversion") == "1") {
+                    suffix = "/8";
+                } else {
+                    suffix = "/32";
+                }
+                return Ext.String.htmlEncode(value) + suffix;
             }
         }],
 


### PR DESCRIPTION
The output of luksDump is now different for containers with luks2. I added also a column to display the container version.
