### PR TITLE
Remove /bin/bash to prevent singles quotes to split using echo

### DIFF
--- a/usr/share/php/openmediavault/system/storage/luks/container.inc
+++ b/usr/share/php/openmediavault/system/storage/luks/container.inc
@@ -628,8 +628,8 @@ class Container extends \OMV\System\Storage\StorageDevice {
                 escapeshellarg($this->getDeviceFile()),
                 escapeshellarg($key));
         } else {
-            $cmd = sprintf("/bin/bash -c 'echo -n %s | ".
-                "cryptsetup luksOpen -v --test-passphrase %s --key-file=-'",
+            $cmd = sprintf("echo -n %s | ".
+                "cryptsetup luksOpen -v --test-passphrase %s --key-file=-",
                 escapeshellarg($key),
                 escapeshellarg($this->getDeviceFile()));
         }


### PR DESCRIPTION
This closes #30 

The method, addKey suffers from the same problem, rendering no output if added key is successful or not