### PR TITLE
Fix mount on container unlock

### DIFF
--- a/usr/share/openmediavault/engined/rpc/luks.inc
+++ b/usr/share/openmediavault/engined/rpc/luks.inc
@@ -20,6 +20,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+use OMV\System\Process;
+
 class OMVRpcServiceLuksMgmt extends \OMV\Rpc\ServiceAbstract {
 
     private $mountOnUnlock = TRUE;
@@ -293,7 +295,86 @@ class OMVRpcServiceLuksMgmt extends \OMV\Rpc\ServiceAbstract {
         // option, OMV_LUKS_MOUNT_ON_UNLOCK - see initialize() above)
         if(TRUE === $this->mountOnUnlock) {
             foreach ($fsDevs as $dev) {
-                \OMV\Rpc\Rpc::call("FsTab", "getByFsName", [ "fsname" => $dev ], $context);
+                $this->mountContainerFS($dev, $context);
+            }
+        }
+    }
+
+    /**
+     * Helper function for mounting filesystems inside containers on unlocking.
+     * @param devicefile The decrypted block special device of the
+     *                   filesystem (inside the LUKS container) to mount.
+     * @param context The context of the caller.
+     * @return None.
+     */
+    private function mountContainerFS($deviceFile, $context) {
+        if (FALSE !== \OMV\Rpc\Rpc::call("FileSystemMgmt", "hasFilesystem", 
+                [ "devicefile" => $deviceFile ], $context)) {
+            $meObject = \OMV\Rpc\Rpc::call("FsTab", "getByFsName", 
+                [ "fsname" => $deviceFile ], $context);
+            if (FALSE !== $meObject) {
+                switch (strtolower($meObject['type'])) {
+                case "btrfs":
+                    /**
+                     * Check if the unlocked device is part of a multi-
+                     * device BTRFS filesystem, and don't attempt to mount
+                     * it if it's not ready (not all devices are available,
+                     * e.g. if more containers must be unlocked first, wait
+                     * until they are all open).
+                     * Note: using 'btrfs device ready' only works for the
+                     * first time devices are opened - even if LUKS devices
+                     * that are part of a multi-device BTRFS filesystem are
+                     * later closed, some information is cached and so btrfs
+                     * subsequently always reports the filesystem as ready.
+                     * Hence, this workaround checks the number of devices
+                     * online for the filesystem via 'btrfs filesystem show'
+                     * instead, which should be more reliable.
+                     * TODO: submit a patch to the core BTRFS backend that
+                     * exposes this in a class function instead?
+                     */
+                    // Find out how many devices are in the filesystem
+                    $cmd = sprintf("export LANG=C; btrfs filesystem ".
+                                    "show %s | grep 'Total devices' | ".
+                                    "awk '{print $3}'",
+                                    escapeshellarg($meObject['fsname']));
+                    $process = new Process($cmd);
+                    $process->execute($output,$result);
+                    $totalDevices = (int)$output[0];
+                    // If the fs has fewer than one device (an error
+                    // of some kind occurred), skip mounting
+                    if($totalDevices < 1)
+                        continue;
+                    unset($cmd, $output, $result);
+                    // Find out how many are online
+                    $cmd = sprintf("export LANG=C; btrfs filesystem ".
+                                    "show %s | grep 'devid' | wc -l",
+                                    escapeshellarg($meObject['fsname']));
+                    $process = new Process($cmd);
+                    $process->execute($output,$result);
+                    $availableDevices = (int)$output[0];
+                    // If not all devices are online, skip mounting
+                    if($availableDevices !== $totalDevices)
+                        continue;
+                    unset($cmd, $output, $result);
+                case "ext2":
+                case "ext3":
+                case "ext4":
+                case "jfs":
+                case "xfs":
+                case "hfsplus":
+                case "reiserfs":
+                case "iso9660":
+                case "udf":
+                case "vfat":
+                case "ntfs":
+                default:
+                    \OMV\Rpc\Rpc::call("FileSystemMgmt", "mount",
+                        [
+                            "id" => $meObject['fsname'],
+                            "fstab" => FALSE
+                        ],
+                        $context);
+                }
             }
         }
     }


### PR DESCRIPTION
This commit goes back to the original code by Ian Grant. A couple of fixes where corrected, some missing import for class function process.

Just a note, btrfs multidevice unlock works only if the filesystem has been registered with omv db backend using a label. If the device was registered without label then omv will mount the fs as

`/srv/dev-by-id-dm-name-sdb-crypt` for example, and in a multidevice the user will have to unlock the device in proper order leaving sdb as the last one, otherwise won't work.

This hopefully closes #35 

TODO: Implement auto mounting of mergerfs points