### PR TITLE
Fixed broken icon for unlocked status in workbench

### DIFF
--- a/usr/share/openmediavault/workbench/component.d/omv-storage-luks-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-storage-luks-datatable-page.yaml
@@ -23,7 +23,7 @@ data:
         sortable: true
         cellTemplateName: binaryUnit
       - name: _("Unlocked")
-        prop: unlock
+        prop: unlocked
         flexGrow: 1
         cellTemplateName: checkIcon
       - name: _("Decrypted Device")


### PR DESCRIPTION
Icon for unlocking status in workbench is broken (at least in OMV 6) due to wrong property name.