### PR TITLE
fix: quoting collision for luks passphrases with spaces

### DIFF
--- a/usr/share/openmediavault/workbench/component.d/omv-storage-luks-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-storage-luks-datatable-page.yaml
@@ -369,7 +369,8 @@ data:
                       request:
                         service: LuksMgmt
                         method: testContainerKey
-                    successUrl: /storage/luks
+                        progressMessage: _("Testing passphrase ...")
+                        successNotification: _("The passphrase matches a key slot on the device.")
           - text: _("Erase slot")
             icon: mdi:delete-forever-outline
             enabledConstraints:

--- a/usr/share/php/openmediavault/system/storage/luks/container.inc
+++ b/usr/share/php/openmediavault/system/storage/luks/container.inc
@@ -567,7 +567,7 @@ class Container extends \OMV\System\Storage\StorageDevice {
             $cmd .= sprintf(" <(echo -n %s)", escapeshellarg($new));
             // N.B. Need to use bash rather than default sh here for
             // process substitution method of injecting new passphrase
-            $cmd = sprintf("/bin/bash -c '%s'", $cmd);
+            $cmd = sprintf("/bin/bash -c %s", escapeshellarg($cmd));
         }
         $process = new Process($cmd);
         $process->setRedirect2to1();
@@ -612,7 +612,7 @@ class Container extends \OMV\System\Storage\StorageDevice {
             $cmd .= sprintf("<(echo -n %s)", escapeshellarg($new));
             // N.B. Need to use bash rather than default sh here for
             // process substitution method of injecting new passphrase
-            $cmd = sprintf("/bin/bash -c '%s'", $cmd);
+            $cmd = sprintf("/bin/bash -c %s", escapeshellarg($cmd));
         }
         // Execute
         $process = new Process($cmd);
@@ -637,8 +637,8 @@ class Container extends \OMV\System\Storage\StorageDevice {
                 escapeshellarg($this->getDeviceFile()),
                 escapeshellarg($key));
         } else {
-            $cmd = sprintf("/bin/bash -c 'echo -n %s | ".
-                "cryptsetup luksRemoveKey -q %s --key-file=-'",
+            $cmd = sprintf("echo -n %s | ".
+                "cryptsetup luksRemoveKey -q %s --key-file=-",
                 escapeshellarg($key),
                 escapeshellarg($this->getDeviceFile()));
         }
@@ -685,8 +685,8 @@ class Container extends \OMV\System\Storage\StorageDevice {
                 escapeshellarg($this->getDeviceFile()),
                 escapeshellarg($key));
         } else {
-            $cmd = sprintf("/bin/bash -c 'echo -n %s | ".
-                "cryptsetup luksOpen -v --test-passphrase %s --key-file=-'",
+            $cmd = sprintf("echo -n %s | ".
+                "cryptsetup luksOpen -v --test-passphrase %s --key-file=-",
                 escapeshellarg($key),
                 escapeshellarg($this->getDeviceFile()));
         }
@@ -694,9 +694,13 @@ class Container extends \OMV\System\Storage\StorageDevice {
         // Test the key and get the key slot number if successful
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            return FALSE;
+        }
         if ($exitStatus !== 0) {
-            throw new \OMV\Exception($output);
+            return FALSE;
         }
         $slot = explode(" ", $output[0])[2];
         // Return which key slot was unlocked.

--- a/usr/share/php/openmediavault/system/storage/luks/container.inc
+++ b/usr/share/php/openmediavault/system/storage/luks/container.inc
@@ -411,7 +411,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
         }
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output);
+        try {
+            $process->execute($output);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }
@@ -483,7 +487,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
             escapeshellarg($header_size));
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }
@@ -514,7 +522,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
         }
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return $exitStatus === 0;
     }
@@ -528,7 +540,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
             escapeshellarg($this->getDecryptedName()));
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }
@@ -571,7 +587,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
         }
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }
@@ -617,7 +637,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
         // Execute
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }
@@ -644,7 +668,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
         }
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }
@@ -663,7 +691,11 @@ class Container extends \OMV\System\Storage\StorageDevice {
             escapeshellarg($slot));
         $process = new Process($cmd);
         $process->setRedirect2to1();
-        $process->execute($output, $exitStatus);
+        try {
+            $process->execute($output, $exitStatus);
+        } catch (\Exception $e) {
+            throw new \OMV\Exception(implode("\n", (array)$output) ?: "cryptsetup command failed.");
+        }
         $this->refresh();
         return TRUE;
     }


### PR DESCRIPTION
When managing LUKS containers via the Web GUI, users reported that passphrases containing spaces (e.g., 'my phrase') were behaving unexpectedly:

- Testing an invalid passphrase with a space incorrectly reported success.
- Opening a container with a valid passphrase containing spaces failed.
- The UI provided no visible success feedback when a key test succeeded, and it threw a raw HTTP 500 error containing the shell execution string when it failed.

The core issue was a quoting collision in `/usr/share/php/openmediavault/system/storage/luks/container.inc`.

The system uses PHP's `escapeshellarg()` to safely wrap the passphrase in single quotes (e.g., 'my password'). However, the resulting command string was then being manually wrapped in another set of single quotes when passed to `/bin/bash -c`. For example,

-  `$cmd = sprintf("/bin/bash -c 'echo -n %s | cryptsetup ...'", escapeshellarg($key));`

When passed to bash, this resulted in a command like:

- `/bin/bash -c 'echo -n 'my password' | cryptsetup...'`

Because of the nested quotes, bash interpreted the command up to the first space after the inner quote: `echo -n my`. The remainder of the string `(password' | cryptsetup...`) was ignored. Since echo executed successfully, bash returned an exit code of 0. This caused the backend to incorrectly assume the cryptsetup action succeeded, leading to false  positives when testing invalid keys.

PR summary:

1. Fixed shell escaping in container.inc
- Removed `/bin/bash -c` wrappers where unnecessary: For `testKey()` and `removeKey()`, the simple pipe (`|`) does not require bash and runs perfectly well under the standard shell spawned by the Process class.
- Fixed escaping for process substitution: For `addKey()` and `changeKey()`, which rely on bash-specific process substitution (`<()`), the command is now constructed safely by passing the entire generated string into `escapeshellarg()` rather than manually wrapping it in single quotes.

2. Improved error handling in `testKey()`
- Why: When cryptsetup fails (e.g., exit code 2 for a bad passphrase), OMV's Process class throws an exception. Previously, this exception went unhandled, resulting in a raw HTTP 500 Internal Server Error in the UI that exposed the exact shell command used.
- Change: Wrapped the `execute()` call in a try/catch block. It now safely returns FALSE on failure, allowing the upstream RPC service (luks.inc) to throw a clean, localized error message: `"The key did not unlock any key slot on the device."`

3. Added UI feedback for Key Testing
- Why: The frontend component was configured to reload the current route immediately on success (successUrl: `/storage/luks`), which destroyed the toast notification before the user could see it. It was also missing a success notification definition.
- Change: Added `progressMessage` and `successNotification` to the `testContainerKey` execution block in `omv-storage luks-datatable-page.yaml`. Removed the `successUrl` property so that the success toast remains visible without forcing a route reload.

Also addressed the issue of echoing back the password in plaintest in the frontend.

Potentially fixes #30, #32, #48 